### PR TITLE
docs: add PR title convention

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,7 +29,12 @@ Common `type` values:
 - `test` – Adding or modifying tests.
 - `chore` – Routine tasks such as dependency updates.
 
+
 The subject should be concise (preferably under 50 characters). Provide additional details in the body if needed.
+
+## Pull Request Guidelines
+
+Pull request titles must use the same `type(scope?): subject` format as commits. Keep the description brief and mention any test results in the body.
 
 ## Testing and Validation
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,7 +34,7 @@ The subject should be concise (preferably under 50 characters). Provide addition
 
 ## Pull Request Guidelines
 
-Pull request titles must use the same `type(scope?): subject` format as commits. Keep the description brief and mention any test results in the body.
+Pull request titles must use the same `type(scope?): subject` format as commits. The body should start with a short summary in the same style and include any test results.
 
 ## Testing and Validation
 


### PR DESCRIPTION
## Summary
- specify that pull request titles must follow Conventional Commits format in `AGENTS.md`

## Testing
- `yamllint .` *(fails: line-length warnings and other lint errors)*
- `espanso check` *(fails: `espanso` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c83480b008327bb793fadcc2fa0cd